### PR TITLE
Show usage Help when input file is not provided in the CLI options

### DIFF
--- a/src/Yarm.ConsoleApp/Options.cs
+++ b/src/Yarm.ConsoleApp/Options.cs
@@ -10,13 +10,13 @@ namespace Yarm.ConsoleApp
         /// <summary>
         /// Gets or sets the input file path.
         /// </summary>
-        [Option('i', "input", Required = false, HelpText = "Input file name and path. If path is omitted, it assumes the current directory.")]
+        [Option('i', "input", Required = true, HelpText = "Name or absolute path of source file.")]
         public string InputPath { get; set; }
 
         /// <summary>
         /// Gets or sets the output file path.
         /// </summary>
-        [Option('o', "output", Required = false, HelpText = "Output file name and path. If path is omitted, it assumes the current directory.")]
+        [Option('o', "output", Required = false, HelpText = "Name or absolute path or output file. If omitted, assumes current directory and same filename with target extension.")]
         public string OuptputPath { get; set; }
     }
 }


### PR DESCRIPTION
This PR fixes issue #2 

-i (--input) set as mandatory so that CommandLineParser shows usage help when option is not given. 
Updated help text for both options (-i and -o) to better reflect what is expected (files not directories)